### PR TITLE
ServiceとExceptionHandlerの実装

### DIFF
--- a/src/main/java/com/work/kadai8/MemberController.java
+++ b/src/main/java/com/work/kadai8/MemberController.java
@@ -1,16 +1,10 @@
 package com.work.kadai8;
 
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 public class MemberController {
@@ -26,22 +20,8 @@ public class MemberController {
         return memberService.findAll();
     }
 
-
     @GetMapping("/member/{id}")
     public Member getMember(@PathVariable("id") int id) {
         return memberService.findById(id);
     }
-
-    @ExceptionHandler(value = MemberNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
-            MemberNotFoundException e, HttpServletRequest request) {
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-                "message", e.getMessage(),
-                "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
-    }
-
 }

--- a/src/main/java/com/work/kadai8/MemberController.java
+++ b/src/main/java/com/work/kadai8/MemberController.java
@@ -9,7 +9,7 @@ import java.util.List;
 @RestController
 public class MemberController {
 
-    private MemberService memberService;
+    private final MemberService memberService;
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;

--- a/src/main/java/com/work/kadai8/MemberController.java
+++ b/src/main/java/com/work/kadai8/MemberController.java
@@ -1,27 +1,47 @@
 package com.work.kadai8;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class MemberController {
 
-    private final MemberMapper memberMapper;
+    private MemberService memberService;
 
-    public MemberController(MemberMapper memberMapper) {
-        this.memberMapper = memberMapper;
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
     }
 
     @GetMapping("/member")
     public List<Member> getAll() {
-        return memberMapper.getAll();
+        return memberService.findAll();
     }
 
+
     @GetMapping("/member/{id}")
-    public List<Member> findById(@PathVariable("id") int id) {
-        return memberMapper.findByMemberId(id);
+    public Member getMember(@PathVariable("id") int id) {
+        return memberService.findById(id);
     }
+
+    @ExceptionHandler(value = MemberNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
+            MemberNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
 }

--- a/src/main/java/com/work/kadai8/MemberMapper.java
+++ b/src/main/java/com/work/kadai8/MemberMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Mapper
@@ -13,6 +14,6 @@ public interface MemberMapper {
     List<Member> getAll();
 
     @Select("SELECT * FROM members WHERE id = #{id}")
-    List<Member> findByMemberId(int id);
+    Optional<Member> findByMemberId(int id);
 
 }

--- a/src/main/java/com/work/kadai8/MemberNotFoundException.java
+++ b/src/main/java/com/work/kadai8/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.work.kadai8;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException(String message) {
+        super(message);
+
+    }
+}

--- a/src/main/java/com/work/kadai8/MemberNotFoundException.java
+++ b/src/main/java/com/work/kadai8/MemberNotFoundException.java
@@ -3,6 +3,5 @@ package com.work.kadai8;
 public class MemberNotFoundException extends RuntimeException {
     public MemberNotFoundException(String message) {
         super(message);
-
     }
 }

--- a/src/main/java/com/work/kadai8/MemberNotFoundExceptionHandler.java
+++ b/src/main/java/com/work/kadai8/MemberNotFoundExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.work.kadai8;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class MemberNotFoundExceptionHandler {
+    @ExceptionHandler(value = MemberNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleMemberNotFoundException(
+            MemberNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/work/kadai8/MemberService.java
+++ b/src/main/java/com/work/kadai8/MemberService.java
@@ -1,0 +1,29 @@
+package com.work.kadai8;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MemberService {
+    private MemberMapper memberMapper;
+
+    public MemberService(MemberMapper memberMapper) {
+        this.memberMapper = memberMapper;
+    }
+
+    public List<Member> findAll() {
+        return memberMapper.getAll();
+    }
+
+
+    public Member findById(int id) {
+        Optional<Member> member = this.memberMapper.findByMemberId(id);
+        if (member.isPresent()) {
+            return member.get();
+        } else {
+            throw new MemberNotFoundException("member not found");
+        }
+    }
+}

--- a/src/main/java/com/work/kadai8/MemberService.java
+++ b/src/main/java/com/work/kadai8/MemberService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 @Service
 public class MemberService {
-    private MemberMapper memberMapper;
+    private final MemberMapper memberMapper;
 
     public MemberService(MemberMapper memberMapper) {
         this.memberMapper = memberMapper;


### PR DESCRIPTION
# 概要
第9回課題でServiceとExceptionHandlerの実装を行いました。

## 動作確認
![スクリーンショット 2024-03-01 0 17 41](https://github.com/Masaki-0225/kadai8/assets/134192771/b9fb85f7-a89a-4faa-8093-959ea8b07de9)

- レスポンスボディとステータスコード404を確認
### curlで確認

```
curl --location 'http://localhost:8080/member/435' -i
HTTP/1.1 404 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 29 Feb 2024 15:21:24 GMT
{
"message":"member not found",
"status":"404",
"path":"/member/435"
,"error":"Not Found",
"timestamp":"2024-03-01T00:21:24.947978+09:00[Asia/Tokyo]"
}
```

- Content-Type: application/jsonを確認
